### PR TITLE
Chaos Darmstadt e.V. -> Chaos Computer Club Darmstadt e.V.

### DIFF
--- a/calendar.ics
+++ b/calendar.ics
@@ -28,7 +28,7 @@ DTSTART;TZID=Europe/Berlin:20180111T190000
 DTEND;TZID=Europe/Berlin:20180111T220000
 DESCRIPTION:Öffentlicher Stammtisch zur Programmiersprache Python\nNäher
  e Infos: https://pystada.github.io/
-LOCATION:CDA Chaos Darmstadt e.V.\, Wilhelminenstraße 17\, 64283 Darmstad
+LOCATION:Chaos Computer Club Darmstadt e.V.\, Wilhelminenstraße 17\, 64283 Darmstad
  t
 URL:https://pystada.github.io
 SEQUENCE:5
@@ -45,7 +45,7 @@ DTSTART;TZID=Europe/Berlin:20180222T190000
 DTEND;TZID=Europe/Berlin:20180222T220000
 DESCRIPTION:Öffentlicher Stammtisch zur Programmiersprache Python\nNäher
  e Infos: https://pystada.github.io/
-LOCATION:CDA Chaos Darmstadt e.V.\, Wilhelminenstraße 17\, 64283 Darmstad
+LOCATION:Chaos Computer Club Darmstadt e.V.\, Wilhelminenstraße 17\, 64283 Darmstad
  t
 URL:https://pystada.github.io
 SEQUENCE:4

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 </ul>
 
         <address style="margin-left: 28px;">
-          <em><a href="https://www.chaos-darmstadt.de/">Chaos Darmstadt e.V.</a></em><br>
+          <em><a href="https://www.chaos-darmstadt.de/">Chaos Computer Club Darmstadt e.V.</a></em><br>
           Wilhelminenstraße 17<br>
           64283 Darmstadt
         </address>

--- a/index.html.template
+++ b/index.html.template
@@ -60,7 +60,7 @@
         {dates}
 
         <address style="margin-left: 28px;">
-          <em><a href="https://www.chaos-darmstadt.de/">Chaos Darmstadt e.V.</a></em><br>
+          <em><a href="https://www.chaos-darmstadt.de/">Chaos Computer Club Darmstadt e.V.</a></em><br>
           Wilhelminenstraße 17<br>
           64283 Darmstadt
         </address>

--- a/mail.template
+++ b/mail.template
@@ -2,7 +2,7 @@ Hallo,
 
 kommende Woche treffen wir uns wieder zum Darmstädter Python Stammtisch.
 
-Am {date.day}. {month} ab {date.hour}:{date.minute:02} Uhr geht es los, beim CDA - Chaos Darmstadt in der Wilhelminenstraße 17.
+Am {date.day}. {month} ab {date.hour}:{date.minute:02} Uhr geht es los, beim Chaos Computer Club Darmstadt e.V. in der Wilhelminenstraße 17.
 Das Pad zur Planung ist zu finden unter https://pads.darmstadt.ccc.de/p/pystada-{date.year}-{date.month:02}-{date.day:02}
 
 Alle Interessenten sind hiermit herzlich eingeladen. Wir freuen uns auf euch!

--- a/new_meeting.py
+++ b/new_meeting.py
@@ -35,7 +35,7 @@ except locale.Error:
 
 
 RECOMMENDED_MAILING_LISTS = [
-    ("Chaos Darmstadt", "hackspace@lists.metarheinmain.de", "https://lists.metarheinmain.de/mailman/listinfo/darmstadt"),
+    ("Chaos Computer Club Darmstadt e.V.", "hackspace@lists.metarheinmain.de", "https://lists.metarheinmain.de/mailman/listinfo/darmstadt"),
     ("Python-DE", "python-de@python.org", "http://mail.python.org/mailman/listinfo/python-de"),
 ]
 


### PR DESCRIPTION
Chaos Darmstadt e.V. recently renamed to Chaos Computer Club Darmstadt e.V., so let's update names on the website as well.